### PR TITLE
Handle long HMI list items

### DIFF
--- a/MVP/MVP.ino
+++ b/MVP/MVP.ino
@@ -39,7 +39,14 @@ static void HMI_WriteString(uint16_t addr, const char* text) {
 static void HMI_WriteListItem(uint16_t listAddr, uint16_t index, const char* text) {
   if (!text) text = "";
   const uint32_t len = (uint32_t)strlen(text) + 1;
-  lumen_write_variable_list(listAddr, index, (uint8_t*)text, len);
+  if (len <= MAX_STRING_SIZE) {
+    lumen_write_variable_list(listAddr, index, (uint8_t*)text, len);
+  } else {
+    uint8_t buf[MAX_STRING_SIZE];
+    memcpy(buf, text, MAX_STRING_SIZE - 1);
+    buf[MAX_STRING_SIZE - 1] = '\0';
+    lumen_write_variable_list(listAddr, index, buf, MAX_STRING_SIZE);
+  }
   delay(3);
 }
 static void HMI_ClearListTail(uint16_t listAddr, uint16_t fromIndex, uint16_t toIndex) {


### PR DESCRIPTION
## Summary
- safeguard list writes by truncating strings that exceed MAX_STRING_SIZE
- preserve processing delay after each list item sent

## Testing
- `g++ -x c++ -fsyntax-only MVP/MVP.ino` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d299b6550832298e647025791f636