### PR TITLE
docs: add German language example

### DIFF
--- a/MVP/MVP.ino
+++ b/MVP/MVP.ino
@@ -120,7 +120,7 @@ static bool readFileToString(const char* path, String &out) {
   f.close();
   return true;
 }
-// Parser minimalista para {"lang":"EN"/"PT"/"ES"}
+// Parser minimalista para {"lang":"EN"/"PT"/"ES"/"DE"}
 static int32_t parseLangIndexFromJson(const String& json) {
   String lower = json; lower.toLowerCase();
   int pos = lower.indexOf("\"lang\"");

--- a/MVP/README.txt
+++ b/MVP/README.txt
@@ -5,7 +5,7 @@ O que este pacote faz
 ---------------------
 - Troca de idioma controlada pelo ESP32 (config salva em /config.json no SPIFFS).
 - Atualiza os rótulos "Configurações/Settings" e "Iniciar/Start" na HMI.
-- Escuta mudanças da variável `Lang` vindas da HMI (0=PT, 1=EN) e salva a escolha.
+- Escuta mudanças da variável `Lang` vindas da HMI (0=PT, 1=EN, 2=ES, 3=DE) e salva a escolha.
 
 Arquivos incluídos
 ------------------
@@ -47,12 +47,16 @@ ou
 {
   "lang": "EN"
 }
+ou
+{
+  "lang": "DE"
+}
 
 Fluxo de teste
 --------------
 1) Compile e grave o sketch no ESP32.
 2) Garanta que a HMI está com UART0 + Lumen Protocol (115200 8N1, sem CRC/Ack).
-3) Na HMI, altere a variável `Lang` (ex.: em um botão PT/EN com "Set Variable").
+3) Na HMI, altere a variável `Lang` (ex.: em um botão PT/EN/DE com "Set Variable").
 4) Veja o rótulo mudar:
    - `txt_Config`: "Configurações" / "Settings"
    - `txt_Start` : "Iniciar" / "Start"

--- a/MVP/config.json
+++ b/MVP/config.json
@@ -1,3 +1,3 @@
 {
-  "lang": "EN"
+  "lang": "DE"
 }


### PR DESCRIPTION
## Summary
- set default language code to DE
- document German language code in README
- note DE example in JSON parser comment

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_689e6eacbac4832280421bd27f5f8051