### PR TITLE
Fix missing opening brace in Spanish translations

### DIFF
--- a/es.json
+++ b/es.json
@@ -1,4 +1,5 @@
-"home.title": "Smart Dent",
+{
+  "home.title": "Smart Dent",
   "home.subtitle": "Sistema de Post-Curado Dental",
   "home.startCure": "Iniciar Curado",
   "home.startCure.desc": "Seleccionar resina e iniciar proceso de curado",


### PR DESCRIPTION
## Summary
- fix es.json by adding missing opening brace so JSON is valid

## Testing
- `jq '.' es.json`

------
https://chatgpt.com/codex/tasks/task_e_689e6ea2e18c832295dfee40ea95658a