### PR TITLE
Use HMI variable packets

### DIFF
--- a/MVP/MVP.ino
+++ b/MVP/MVP.ino
@@ -8,6 +8,7 @@
 #include "hmi_bindings.h"
 #include "hmi_renderer.h"
 #include "smartcure_translations.h"
+#include "user_variables.h"
 
 // ======= Config =======
 #define HMI_RX     16
@@ -104,6 +105,9 @@ void setup(){
   delay(800);                 // HMI sobe
   HMI_FillLanguageList();     // popula 126
 
+  lumen_write(&langPacket, 0);                 // idioma default = inglês
+  lumen_write(&txt_start_curePacket, "Start Cure");
+
   // Carrega idioma inicial
   int32_t cfgIdx = -1; String js;
   if (readFileToString("/config.json", js)){
@@ -130,10 +134,10 @@ void loop(){
       (const char*)pkt.data._string);
 #endif
 
-    if (pkt.address == ADDR_LIST_LANG || pkt.address == ADDR_LANG_VAR){
+    if (pkt.address == langListPacket.address || pkt.address == langPacket.address){
       int32_t idx = extractIndexLoose(pkt);
       if (idx != INT32_MIN){
-        bool mirror = (pkt.address == ADDR_LIST_LANG); // vindo da lista, espelha 123
+        bool mirror = (pkt.address == langListPacket.address); // vindo da lista, espelha 123
         applyLanguageIdx(constrain(idx,0,3), mirror);
       } else {
         Serial.println("[EVT] pacote de idioma sem valor reconhecível.");

--- a/MVP/user_variables.h
+++ b/MVP/user_variables.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "LumenProtocol.h"
+#include "hmi_addresses.h"
+#include <string.h>
+
+// Predefined packets for HMI user variables
+static lumen_packet_t langPacket = { ADDR_LANG_VAR, kS32 };
+static lumen_packet_t langListPacket = { ADDR_LIST_LANG, kS32 };
+static lumen_packet_t txt_start_curePacket = { ADDR_TXT_START, kString };
+
+// Overloaded helpers for writing values to the HMI variables
+inline void lumen_write(lumen_packet_t* p, int32_t value) {
+  p->type = kS32;
+  p->data._s32 = value;
+  lumen_write_packet(p);
+}
+
+inline void lumen_write(lumen_packet_t* p, const char* value) {
+  p->type = kString;
+  if (!value) {
+    p->data._string[0] = '\0';
+  } else {
+    strncpy(p->data._string, value, sizeof(p->data._string) - 1);
+    p->data._string[sizeof(p->data._string) - 1] = '\0';
+  }
+  lumen_write_packet(p);
+}
+


### PR DESCRIPTION
## Summary
- centralize HMI user variables in new `user_variables.h`
- initialize default language and start text using packet writes
- replace direct address checks with packet-based references

## Testing
- `g++ -std=c++11 -x c++ -I MVP -c MVP/MVP.ino` *(fails: fatal error: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a212914d388322bb877de95fe1c784