### PR TITLE
Add translations and update header

### DIFF
--- a/MVP/smartcure_translations.h
+++ b/MVP/smartcure_translations.h
@@ -153,8 +153,15 @@ typedef enum {
   ID_COMMON_CONFIRM = 608,
   ID_COMMON_YES = 609,
   ID_COMMON_NO = 610,
+  ID_TXT_CONFIG = 611,
+  ID_TXT_START_CURE = 612,
+  ID_TXT_LANG = 613,
+  ID_TXT_ADMIN = 614,
+  ID_TXT_SYSTEM = 615,
+  ID_START_GLAZE_CURE = 616,
+  ID_TXT_SECONDS = 617,
 } StringId;
-static const char* STR_EN[511] = {
+static const char* STR_EN[518] = {
   "Smart Dent",
   "Dental Post-Curing System",
   "Start Curing",
@@ -666,8 +673,15 @@ static const char* STR_EN[511] = {
   "Confirm",
   "Yes",
   "No",
+  "Settings",
+  "Start Cure",
+  "Language",
+  "Admin",
+  "System Information",
+  "Start Glaze Cure",
+  "Seconds",
 };
-static const char* STR_PT[511] = {
+static const char* STR_PT[518] = {
   "Smart Dent",
   "Sistema de Pós-Cura Dental",
   "Iniciar Cura",
@@ -1179,8 +1193,15 @@ static const char* STR_PT[511] = {
   "Confirmar",
   "Sim",
   "Não",
+  "Configurações",
+  "Iniciar Cura",
+  "Idioma",
+  "Admin",
+  "Informações do Sistema",
+  "Iniciar Cura do Glaze",
+  "Segundos",
 };
-static const char* STR_ES[511] = {
+static const char* STR_ES[518] = {
   "Smart Dent",
   "Sistema de Post-Curado Dental",
   "Iniciar Curado",
@@ -1692,8 +1713,15 @@ static const char* STR_ES[511] = {
   "Confirmar",
   "Sí",
   "No",
+  "Configuración",
+  "Iniciar Curado",
+  "Idioma",
+  "Admin",
+  "Información del Sistema",
+  "Iniciar Curado de Glaze",
+  "Segundos",
 };
-static const char* STR_DE[511] = {
+static const char* STR_DE[518] = {
   "Smart Dent",
   "Zahnärztliches System nach der Heizung",
   "Fang zu heilen",
@@ -2205,6 +2233,13 @@ static const char* STR_DE[511] = {
   "Bestätigen",
   "Ja",
   "NEIN",
+  "Einstellungen",
+  "Aushärtung starten",
+  "Sprache",
+  "Administrator",
+  "Systeminformationen",
+  "Glasurhärtung starten",
+  "Sekunden",
 };
 
 static inline const char** _tbl(Language lang) {
@@ -2218,7 +2253,7 @@ static inline const char** _tbl(Language lang) {
 }
 static inline const char* getString(Language lang, StringId id) {
   int idx = (int)id - 100;
-  if (idx < 0 || idx >= 511) return "";
+  if (idx < 0 || idx >= 518) return "";
   return _tbl(lang)[idx];
 }
 

--- a/de.json
+++ b/de.json
@@ -147,5 +147,12 @@
   "common.add": "Hinzufügen",
   "common.confirm": "Bestätigen",
   "common.yes": "Ja",
-  "common.no": "Nein"
+  "common.no": "Nein",
+  "txt_config": "Einstellungen",
+  "txt_start_cure": "Aushärtung starten",
+  "txt_lang": "Sprache",
+  "txt_admin": "Administrator",
+  "txt_system": "Systeminformationen",
+  "start_glaze_cure": "Glasurhärtung starten",
+  "txt_seconds": "Sekunden"
 }

--- a/en.json
+++ b/en.json
@@ -156,5 +156,12 @@
   "common.add": "Add",
   "common.confirm": "Confirm",
   "common.yes": "Yes",
-  "common.no": "No"
+  "common.no": "No",
+  "txt_config": "Settings",
+  "txt_start_cure": "Start Cure",
+  "txt_lang": "Language",
+  "txt_admin": "Admin",
+  "txt_system": "System Information",
+  "start_glaze_cure": "Start Glaze Cure",
+  "txt_seconds": "Seconds"
 }

--- a/es.json
+++ b/es.json
@@ -156,5 +156,12 @@
   "common.add": "Agregar",
   "common.confirm": "Confirmar",
   "common.yes": "Sí",
-  "common.no": "No"
+  "common.no": "No",
+  "txt_config": "Configuración",
+  "txt_start_cure": "Iniciar Curado",
+  "txt_lang": "Idioma",
+  "txt_admin": "Admin",
+  "txt_system": "Información del Sistema",
+  "start_glaze_cure": "Iniciar Curado de Glaze",
+  "txt_seconds": "Segundos"
 }

--- a/pt.json
+++ b/pt.json
@@ -156,5 +156,12 @@
   "common.add": "Adicionar",
   "common.confirm": "Confirmar",
   "common.yes": "Sim",
-  "common.no": "Não"
+  "common.no": "Não",
+  "txt_config": "Configurações",
+  "txt_start_cure": "Iniciar Cura",
+  "txt_lang": "Idioma",
+  "txt_admin": "Admin",
+  "txt_system": "Informações do Sistema",
+  "start_glaze_cure": "Iniciar Cura do Glaze",
+  "txt_seconds": "Segundos"
 }


### PR DESCRIPTION
## Summary
- add missing text identifiers to English, Portuguese, Spanish and German translation files
- extend smartcure_translations.h with new string IDs and translations
- expand translation tables and bounds checking for new entries

## Testing
- `jq . en.json`
- `jq . pt.json`
- `jq . es.json`
- `jq . de.json`
- `g++ -std=c++17 -fsyntax-only MVP/smartcure_translations.h`
- `g++ -std=c++17 -c MVP/hmi_renderer.cpp` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a21292ce28832281ba43b586c34dc5