### PR TITLE
Document additional user variables

### DIFF
--- a/MVP/user_variables.h
+++ b/MVP/user_variables.h
@@ -66,6 +66,10 @@ const uint16_t pre_cure_5Address       = 134; // Pre-cure step 5 duration (s)
 const uint16_t pre_cure_6Address       = 135; // Pre-cure step 6 duration (s)
 const uint16_t pre_cure_7Address       = 136; // Pre-cure step 7 duration (s)
 const uint16_t txt_secondsAddress      = 137; // "Seconds" label
+const uint16_t selected_pre_cureAddress = 138; // Selected pre-cure duration (s)
+const uint16_t time_curandoAddress      = 139; // Elapsed cure time (s)
+const uint16_t timer_start_stopAddress  = 140; // Timer command/state (0=stop,1=start,3=pause)
+const uint16_t progress_permilleAddress = 141; // Progress bar value (0–1000)
 
 // Packet instances
 static lumen_packet_t main_screenPacket      = { main_screenAddress, kS32 };   // Selected screen ID
@@ -85,5 +89,9 @@ static lumen_packet_t pre_cure_5Packet       = { pre_cure_5Address, kS32 };    /
 static lumen_packet_t pre_cure_6Packet       = { pre_cure_6Address, kS32 };    // Pre-cure stage 6 time in seconds
 static lumen_packet_t pre_cure_7Packet       = { pre_cure_7Address, kS32 };    // Pre-cure stage 7 time in seconds
 static lumen_packet_t txt_secondsPacket      = { txt_secondsAddress, kString }; // Seconds label text
+static lumen_packet_t selected_pre_curePacket = { selected_pre_cureAddress, kS32 }; // Selected pre-cure time in seconds
+static lumen_packet_t time_curandoPacket     = { time_curandoAddress,      kS32 }; // Elapsed cure time in seconds
+static lumen_packet_t timer_start_stopPacket = { timer_start_stopAddress,  kS32 }; // Timer state
+static lumen_packet_t progress_permillePacket= { progress_permilleAddress, kS32 }; // Progress bar value (permille)
 
 #endif // USER_VARIABLES_H

--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -4,15 +4,26 @@
 
 The UnicView project uses the following user-variable addresses. The mapping was verified against `mvp.uvs` (UnicView/V_Vision project file) and the constants defined in `MVP/user_variables.h`.
 
-| Address | Designator        | Description |
-|---------|-------------------|-------------|
-| 121 | Main_Screen | número da tela Main |
-| 122 | txt_Config | word "Settings" in current language |
-| 123 | Lang | language selector 0=EN,1=PT,2=ES,3=DE |
-| 124 | txt_Start_Cure | "Start Cure" text in current language |
-| 125 | txt_Lang | "Language" text in current language |
-| 126 | Lista_de_Idiomas | list of available languages |
-| 127 | txt_Admin | "Admin" text in current language |
-| 128 | txt_System | "System Information" text in current language |
-
-Addresses 129–137 are currently unassigned.
+| Address | Designator        | Type  | Description |
+|---------|-------------------|-------|-------------|
+| 121 | Main_Screen      | S32   | current screen ID |
+| 122 | txt_Config       | String| "Settings" label |
+| 123 | Lang             | S32   | language selector 0=EN,1=PT,2=ES,3=DE |
+| 124 | txt_Start_Cure   | String| "Start Cure" label |
+| 125 | txt_Lang         | String| "Language" label |
+| 126 | Lista_de_Idiomas | S32   | language list index |
+| 127 | txt_Admin        | String| "Admin" label |
+| 128 | txt_System       | String| "System Information" label |
+| 129 | Start_Glaze_Cure | String| "Start Glaze Cure" label |
+| 130 | Pre_Cure_1       | S32   | pre-cure step 1 duration (s) |
+| 131 | Pre_Cure_2       | S32   | pre-cure step 2 duration (s) |
+| 132 | Pre_Cure_3       | S32   | pre-cure step 3 duration (s) |
+| 133 | Pre_Cure_4       | S32   | pre-cure step 4 duration (s) |
+| 134 | Pre_Cure_5       | S32   | pre-cure step 5 duration (s) |
+| 135 | Pre_Cure_6       | S32   | pre-cure step 6 duration (s) |
+| 136 | Pre_Cure_7       | S32   | pre-cure step 7 duration (s) |
+| 137 | txt_Seconds      | String| "Seconds" label |
+| 138 | Selected_Pre_Cure| S32   | selected pre-cure duration (s) |
+| 139 | Time_Curando     | S32   | elapsed cure time (s) |
+| 140 | Timer_Start_Stop | S32   | timer state 0–stop,1–start,3–pause |
+| 141 | progress_permille| S32   | progress bar value (0–1000) |

--- a/SmartCure.ino
+++ b/SmartCure.ino
@@ -41,11 +41,8 @@ extern "C" uint16_t lumen_get_byte() {
  * for pre_cure_1–pre_cure_7.
  */
 
-// Define an additional address for the progress bar permille value.  This
-// address must be added to the UnicView project as a User Variable of type
-// S32.  It should not conflict with existing addresses.  We chose 141 as
-// it follows the existing range up to 140.
-const uint16_t progress_permilleAddress = 141;
+// progress_permilleAddress (141) is declared in user_variables.h. The HMI must
+// define a corresponding S32 User Variable for the 0–1000 progress value.
 
 // Internal state for the timer
 enum CureState { STATE_IDLE = 0, STATE_RUNNING = 1, STATE_PAUSED = 2 };
@@ -71,14 +68,8 @@ static int32_t last_progress_reported = -1;
 // pre‑cure durations used previously: 6s, 15s, 30s, 60s, 90s, 120s, 180s.
 static uint32_t pre_cure_values[7] = {6, 15, 30, 60, 90, 120, 180};
 
-// Create lumen_packet_t instances for each variable we need to write back
-// to the HMI.  The addresses for selected_pre_cure, time_curando and
-// timer_start_stop come from user_variables.h.  We assign our custom
-// progress_permilleAddress here.
-static lumen_packet_t selected_pre_curePacket = { selected_pre_cureAddress, kS32 };
-static lumen_packet_t time_curandoPacket     = { time_curandoAddress,     kS32 };
-static lumen_packet_t timer_start_stopPacket = { timer_start_stopAddress, kS32 };
-static lumen_packet_t progress_permillePacket= { progress_permilleAddress,kS32 };
+// Packet instances for selected_pre_cure, time_curando, timer_start_stop and
+// progress_permille are defined in user_variables.h.
 
 // Helper to write an integer value to the HMI.  It updates the packet
 // structure with the type and data then calls lumen_write_packet().


### PR DESCRIPTION
## Summary
- add selected_pre_cure, time_curando, timer_start_stop and progress_permille addresses
- describe new and existing user variables in Project Notes table
- centralise progress_permille and packet declarations in user_variables.h

## Testing
- `g++ -x c++ -fsyntax-only SmartCure.ino` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a66eab61488322ac73dad803719268