### PR TITLE
Consolidate HMI variable definitions and add timer bindings

### DIFF
--- a/MVP/user_variables.h
+++ b/MVP/user_variables.h
@@ -1,30 +1,58 @@
 #pragma once
-#include <stdint.h>
-
-// UnicView (endereços de User Variables / Widgets)
-static const uint16_t ADDR_MAIN_SCREEN      = 121; // S32 (id de tela, se usar)
-static const uint16_t ADDR_TXT_CONFIG       = 122; // String
-static const uint16_t ADDR_LANG_VAR         = 123; // S32/U16 -> 0=EN,1=PT,2=ES,3=DE
-static const uint16_t ADDR_TXT_START        = 124; // String
-static const uint16_t ADDR_TXT_LANG         = 125; // String
-static const uint16_t ADDR_LIST_LANG        = 126; // Basic Text List (índice 0..3)
-static const uint16_t ADDR_TXT_ADMIN        = 127; // String (ex.: "Admin")
-static const uint16_t ADDR_TXT_SYSTEM       = 128; // String (ex.: subtítulo Settings)
-
-static const uint16_t MAX_LIST_SIZE         = 10;
-=======
-#pragma once
 
 #include "LumenProtocol.h"
-#include "hmi_addresses.h"
+#include <stdint.h>
 #include <string.h>
 
-// Predefined packets for HMI user variables
-static lumen_packet_t langPacket = { ADDR_LANG_VAR, kS32 };
-static lumen_packet_t langListPacket = { ADDR_LIST_LANG, kS32 };
-static lumen_packet_t txt_start_curePacket = { ADDR_TXT_START, kString };
+// UnicView (User Variables / Widgets) addresses
+static const uint16_t ADDR_MAIN_SCREEN       = 121; // S32 (current screen ID)
+static const uint16_t ADDR_TXT_CONFIG        = 122; // String
+static const uint16_t ADDR_LANG_VAR          = 123; // S32/U16 -> 0=EN,1=PT,2=ES,3=DE
+static const uint16_t ADDR_TXT_START         = 124; // String
+static const uint16_t ADDR_TXT_LANG          = 125; // String
+static const uint16_t ADDR_LIST_LANG         = 126; // Basic Text List (index 0..3)
+static const uint16_t ADDR_TXT_ADMIN         = 127; // String (e.g.: "Admin")
+static const uint16_t ADDR_TXT_SYSTEM        = 128; // String (e.g.: subtitle "System")
+static const uint16_t ADDR_START_GLAZE_CURE  = 129; // "Start Glaze Cure" label
+static const uint16_t ADDR_PRE_CURE_1        = 130; // Pre-cure step 1 duration (s, HMI updatable)
+static const uint16_t ADDR_PRE_CURE_2        = 131; // Pre-cure step 2 duration (s, HMI updatable)
+static const uint16_t ADDR_PRE_CURE_3        = 132; // Pre-cure step 3 duration (s, HMI updatable)
+static const uint16_t ADDR_PRE_CURE_4        = 133; // Pre-cure step 4 duration (s, HMI updatable)
+static const uint16_t ADDR_PRE_CURE_5        = 134; // Pre-cure step 5 duration (s, HMI updatable)
+static const uint16_t ADDR_PRE_CURE_6        = 135; // Pre-cure step 6 duration (s, HMI updatable)
+static const uint16_t ADDR_PRE_CURE_7        = 136; // Pre-cure step 7 duration (s, HMI updatable)
+static const uint16_t ADDR_TXT_SECONDS       = 137; // "Seconds" label
+static const uint16_t ADDR_SELECTED_PRE_CURE = 138; // Selected pre-cure preset
+static const uint16_t ADDR_TIME_CURANDO      = 139; // Elapsed curing time (s)
+static const uint16_t ADDR_TIMER_START_STOP  = 140; // Timer control: 0=stop,1=start,3=pause
+static const uint16_t ADDR_PROGRESS_PERMILLE = 141; // Progress bar (0-1000 permille)
 
-// Overloaded helpers for writing values to the HMI variables
+static const uint16_t MAX_LIST_SIZE          = 10;
+
+// Packet instances
+static lumen_packet_t main_screenPacket       = { ADDR_MAIN_SCREEN, kS32 };   // Selected screen ID
+static lumen_packet_t txt_configPacket        = { ADDR_TXT_CONFIG, kString }; // Config label text
+static lumen_packet_t langPacket              = { ADDR_LANG_VAR, kS32 };      // Language setting
+static lumen_packet_t txt_start_curePacket    = { ADDR_TXT_START, kString };  // Start cure label text
+static lumen_packet_t txt_langPacket          = { ADDR_TXT_LANG, kString };   // Language label text
+static lumen_packet_t list_langPacket         = { ADDR_LIST_LANG, kS32 };     // Language list index
+static lumen_packet_t txt_adminPacket         = { ADDR_TXT_ADMIN, kString };  // Admin label text
+static lumen_packet_t txt_systemPacket        = { ADDR_TXT_SYSTEM, kString }; // System label text
+static lumen_packet_t start_glaze_curePacket  = { ADDR_START_GLAZE_CURE, kString }; // Start glaze cure label text
+static lumen_packet_t pre_cure_1Packet        = { ADDR_PRE_CURE_1, kS32 };    // Pre-cure stage 1 time (HMI updatable)
+static lumen_packet_t pre_cure_2Packet        = { ADDR_PRE_CURE_2, kS32 };    // Pre-cure stage 2 time (HMI updatable)
+static lumen_packet_t pre_cure_3Packet        = { ADDR_PRE_CURE_3, kS32 };    // Pre-cure stage 3 time (HMI updatable)
+static lumen_packet_t pre_cure_4Packet        = { ADDR_PRE_CURE_4, kS32 };    // Pre-cure stage 4 time (HMI updatable)
+static lumen_packet_t pre_cure_5Packet        = { ADDR_PRE_CURE_5, kS32 };    // Pre-cure stage 5 time (HMI updatable)
+static lumen_packet_t pre_cure_6Packet        = { ADDR_PRE_CURE_6, kS32 };    // Pre-cure stage 6 time (HMI updatable)
+static lumen_packet_t pre_cure_7Packet        = { ADDR_PRE_CURE_7, kS32 };    // Pre-cure stage 7 time (HMI updatable)
+static lumen_packet_t txt_secondsPacket       = { ADDR_TXT_SECONDS, kString }; // Seconds label text
+static lumen_packet_t selected_pre_curePacket = { ADDR_SELECTED_PRE_CURE, kS32 }; // Selected pre-cure preset
+static lumen_packet_t time_curandoPacket      = { ADDR_TIME_CURANDO, kS32 }; // Elapsed curing time (s)
+static lumen_packet_t timer_start_stopPacket  = { ADDR_TIMER_START_STOP, kS32 }; // Timer control state
+static lumen_packet_t progress_permillePacket = { ADDR_PROGRESS_PERMILLE, kS32 }; // Progress 0-1000 (permille)
+
+// Helper functions for writing values to the HMI variables
 inline void lumen_write(lumen_packet_t* p, int32_t value) {
   p->type = kS32;
   p->data._s32 = value;
@@ -42,48 +70,3 @@ inline void lumen_write(lumen_packet_t* p, const char* value) {
   lumen_write_packet(p);
 }
 
-=======
-#ifndef USER_VARIABLES_H
-#define USER_VARIABLES_H
-
-#include "LumenProtocol.h"
-
-// Address constants
-const uint16_t main_screenAddress      = 121; // Current screen ID (default 0)
-const uint16_t txt_configAddress       = 122; // "Config" label
-const uint16_t langAddress             = 123; // Language selection (0=EN,1=PT,2=ES,3=DE)
-const uint16_t txt_start_cureAddress   = 124; // "Start Cure" label
-const uint16_t txt_langAddress         = 125; // "Language" label
-const uint16_t list_langAddress        = 126; // Language list index
-const uint16_t txt_adminAddress        = 127; // "Admin" label
-const uint16_t txt_systemAddress       = 128; // "System" label
-const uint16_t start_glaze_cureAddress = 129; // "Start Glaze Cure" label
-const uint16_t pre_cure_1Address       = 130; // Pre-cure step 1 duration (s)
-const uint16_t pre_cure_2Address       = 131; // Pre-cure step 2 duration (s)
-const uint16_t pre_cure_3Address       = 132; // Pre-cure step 3 duration (s)
-const uint16_t pre_cure_4Address       = 133; // Pre-cure step 4 duration (s)
-const uint16_t pre_cure_5Address       = 134; // Pre-cure step 5 duration (s)
-const uint16_t pre_cure_6Address       = 135; // Pre-cure step 6 duration (s)
-const uint16_t pre_cure_7Address       = 136; // Pre-cure step 7 duration (s)
-const uint16_t txt_secondsAddress      = 137; // "Seconds" label
-
-// Packet instances
-static lumen_packet_t main_screenPacket      = { main_screenAddress, kS32 };   // Selected screen ID
-static lumen_packet_t txt_configPacket       = { txt_configAddress, kString }; // Config label text
-static lumen_packet_t langPacket             = { langAddress, kS32 };          // Language setting
-static lumen_packet_t txt_start_curePacket   = { txt_start_cureAddress, kString }; // Start cure label text
-static lumen_packet_t txt_langPacket         = { txt_langAddress, kString };   // Language label text
-static lumen_packet_t list_langPacket        = { list_langAddress, kS32 };     // Language list index
-static lumen_packet_t txt_adminPacket        = { txt_adminAddress, kString };  // Admin label text
-static lumen_packet_t txt_systemPacket       = { txt_systemAddress, kString }; // System label text
-static lumen_packet_t start_glaze_curePacket = { start_glaze_cureAddress, kString }; // Start glaze cure label text
-static lumen_packet_t pre_cure_1Packet       = { pre_cure_1Address, kS32 };    // Pre-cure stage 1 time in seconds
-static lumen_packet_t pre_cure_2Packet       = { pre_cure_2Address, kS32 };    // Pre-cure stage 2 time in seconds
-static lumen_packet_t pre_cure_3Packet       = { pre_cure_3Address, kS32 };    // Pre-cure stage 3 time in seconds
-static lumen_packet_t pre_cure_4Packet       = { pre_cure_4Address, kS32 };    // Pre-cure stage 4 time in seconds
-static lumen_packet_t pre_cure_5Packet       = { pre_cure_5Address, kS32 };    // Pre-cure stage 5 time in seconds
-static lumen_packet_t pre_cure_6Packet       = { pre_cure_6Address, kS32 };    // Pre-cure stage 6 time in seconds
-static lumen_packet_t pre_cure_7Packet       = { pre_cure_7Address, kS32 };    // Pre-cure stage 7 time in seconds
-static lumen_packet_t txt_secondsPacket      = { txt_secondsAddress, kString }; // Seconds label text
-
-#endif // USER_VARIABLES_H

--- a/SmartCure.ino
+++ b/SmartCure.ino
@@ -32,8 +32,8 @@ extern "C" uint16_t lumen_get_byte() {
  *
  * This sketch centralises all of the timing logic on the ESP32 instead of
  * relying on UnicView operators.  The display simply writes the duration
- * selected by the user (selected_pre_cureAddress) and a command to start,
- * pause or stop (timer_start_stopAddress).  The ESP32 keeps track of the
+ * selected by the user (ADDR_SELECTED_PRE_CURE) and a command to start,
+ * pause or stop (ADDR_TIMER_START_STOP).  The ESP32 keeps track of the
  * elapsed time using millis(), updates the running counter every second and
  * computes a progress bar value from 0–1000 (permille).  When the elapsed
  * time meets or exceeds the selected duration the counter resets and the
@@ -41,18 +41,16 @@ extern "C" uint16_t lumen_get_byte() {
  * for pre_cure_1–pre_cure_7.
  */
 
-// Define an additional address for the progress bar permille value.  This
-// address must be added to the UnicView project as a User Variable of type
-// S32.  It should not conflict with existing addresses.  We chose 141 as
-// it follows the existing range up to 140.
-const uint16_t progress_permilleAddress = 141;
+// Addresses and packet instances for HMI variables are defined in
+// user_variables.h.  They include entries for the timer state, selected
+// preset, elapsed time and progress bar value.
 
 // Internal state for the timer
 enum CureState { STATE_IDLE = 0, STATE_RUNNING = 1, STATE_PAUSED = 2 };
 static CureState cureState = STATE_IDLE;
 
 // Target duration in seconds.  This is set when the HMI writes to
-// selected_pre_cureAddress.  If zero, the timer will not start.
+// ADDR_SELECTED_PRE_CURE.  If zero, the timer will not start.
 static uint32_t target_time_s = 0;
 
 // Timestamp (in milliseconds) when the current run started.  When the timer
@@ -71,14 +69,9 @@ static int32_t last_progress_reported = -1;
 // pre‑cure durations used previously: 6s, 15s, 30s, 60s, 90s, 120s, 180s.
 static uint32_t pre_cure_values[7] = {6, 15, 30, 60, 90, 120, 180};
 
-// Create lumen_packet_t instances for each variable we need to write back
-// to the HMI.  The addresses for selected_pre_cure, time_curando and
-// timer_start_stop come from user_variables.h.  We assign our custom
-// progress_permilleAddress here.
-static lumen_packet_t selected_pre_curePacket = { selected_pre_cureAddress, kS32 };
-static lumen_packet_t time_curandoPacket     = { time_curandoAddress,     kS32 };
-static lumen_packet_t timer_start_stopPacket = { timer_start_stopAddress, kS32 };
-static lumen_packet_t progress_permillePacket= { progress_permilleAddress,kS32 };
+// Packet instances (selected_pre_curePacket, time_curandoPacket,
+// timer_start_stopPacket and progress_permillePacket) are declared in
+// user_variables.h.
 
 // Helper to write an integer value to the HMI.  It updates the packet
 // structure with the type and data then calls lumen_write_packet().
@@ -209,13 +202,13 @@ void loop() {
       default: break;
     }
 
-    if (addr == selected_pre_cureAddress) {
+    if (addr == ADDR_SELECTED_PRE_CURE) {
       // User has chosen a new duration.  Update the target time and echo
       // the value back to the HMI.  A value <= 0 effectively disables
       // the timer until a valid duration is set.
       target_time_s = (value > 0) ? (uint32_t)value : 0;
       writeInt(&selected_pre_curePacket, target_time_s);
-    } else if (addr == timer_start_stopAddress) {
+    } else if (addr == ADDR_TIMER_START_STOP) {
       // The display is commanding the timer: 0=Stop, 1=Start/Resume,
       // 2=Single (treated as Start), 3=Pause.  We interpret and act
       // accordingly on our internal state machine.
@@ -230,19 +223,19 @@ void loop() {
       } else if (value == 3) {
         pauseCure();
       }
-    } else if (addr == pre_cure_1Address) {
+    } else if (addr == ADDR_PRE_CURE_1) {
       pre_cure_values[0] = (value > 0) ? (uint32_t)value : pre_cure_values[0];
-    } else if (addr == pre_cure_2Address) {
+    } else if (addr == ADDR_PRE_CURE_2) {
       pre_cure_values[1] = (value > 0) ? (uint32_t)value : pre_cure_values[1];
-    } else if (addr == pre_cure_3Address) {
+    } else if (addr == ADDR_PRE_CURE_3) {
       pre_cure_values[2] = (value > 0) ? (uint32_t)value : pre_cure_values[2];
-    } else if (addr == pre_cure_4Address) {
+    } else if (addr == ADDR_PRE_CURE_4) {
       pre_cure_values[3] = (value > 0) ? (uint32_t)value : pre_cure_values[3];
-    } else if (addr == pre_cure_5Address) {
+    } else if (addr == ADDR_PRE_CURE_5) {
       pre_cure_values[4] = (value > 0) ? (uint32_t)value : pre_cure_values[4];
-    } else if (addr == pre_cure_6Address) {
+    } else if (addr == ADDR_PRE_CURE_6) {
       pre_cure_values[5] = (value > 0) ? (uint32_t)value : pre_cure_values[5];
-    } else if (addr == pre_cure_7Address) {
+    } else if (addr == ADDR_PRE_CURE_7) {
       pre_cure_values[6] = (value > 0) ? (uint32_t)value : pre_cure_values[6];
     }
   }


### PR DESCRIPTION
## Summary
- clean up duplicated HMI variable declarations
- add addresses and packets for selected pre-cure, elapsed time, timer state and progress
- mark pre-cure presets as HMI-updatable and refactor SmartCure to use unified macros

## Testing
- `g++ -I/tmp/arduino_stub -I MVP -x c++ -c SmartCure.ino -o SmartCure.o`
- `ld -r LumenProtocol.o hmi_renderer.o SmartCure.o -o SmartCure_reloc.o`


------
https://chatgpt.com/codex/tasks/task_e_68a66ea8d15883229d9ae0dd074f55e7